### PR TITLE
feat: spaces generator

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,5 +4,5 @@ subprojects {
     }
 
     group = "net.bladehunt"
-    version = "0.1.0-alpha.1"
+    version = "0.1.0-alpha.2"
 }

--- a/plugin/src/main/kotlin/net/bladehunt/rpp/RppExtension.kt
+++ b/plugin/src/main/kotlin/net/bladehunt/rpp/RppExtension.kt
@@ -1,5 +1,6 @@
 package net.bladehunt.rpp
 
+import net.bladehunt.rpp.spaces.Spaces
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.model.ObjectFactory
@@ -11,6 +12,8 @@ fun Project.rpp(): RppExtension = extensions.create("rpp", RppExtension::class.j
 open class RppExtension @Inject constructor(
     objects: ObjectFactory,
 ) {
+    var spaces: Spaces? = null
+
     var minifyJson: Boolean = true
 
     var outputName: String? = null
@@ -20,6 +23,16 @@ open class RppExtension @Inject constructor(
     val server: RppServerHandler = objects.newInstance(RppServerHandler::class.java)
 
     fun server(action: Action<RppServerHandler>) = action.execute(server)
+
+    fun spaces(
+        namespace: String = "rpp",
+        font: String = "spaces",
+        amount: Int = 8192,
+        className: String? = null,
+        classPackage: String? = null
+    ) {
+        this.spaces = Spaces(namespace, font, amount, className, classPackage)
+    }
 }
 
 open class RppServerHandler {

--- a/plugin/src/main/kotlin/net/bladehunt/rpp/codegen/Codegen.kt
+++ b/plugin/src/main/kotlin/net/bladehunt/rpp/codegen/Codegen.kt
@@ -2,15 +2,33 @@ package net.bladehunt.rpp.codegen
 
 import kotlinx.serialization.json.decodeFromStream
 import net.bladehunt.rpp.Json
+import net.bladehunt.rpp.spaces.Spaces
 import java.io.File
 import java.util.*
 
 internal fun generateCode(
     config: CodegenConfig,
+    spaces: Spaces?,
     assets: File,
     javaOutput: File
 ) {
     if (!javaOutput.deleteRecursively()) throw IllegalStateException("Failed to clean codegen output")
+
+    if (spaces != null) {
+        val className = requireNotNull(spaces.className)
+        val pkg = requireNotNull(spaces.classPackage)
+
+        val packageDir = javaOutput.resolve(pkg.replace('.', '/'))
+        packageDir.mkdirs()
+
+        val fontClass = packageDir.resolve("$className.java")
+
+        fontClass.createNewFile()
+
+        fontClass.outputStream().bufferedWriter().use {
+            it.write(createSpaceClass(className, pkg, spaces.namespace, spaces.font, spaces.amount))
+        }
+    }
 
     config.forEach { (namespace, nsConfig) ->
         nsConfig.fonts?.forEach { (font, fontConfig) ->

--- a/plugin/src/main/kotlin/net/bladehunt/rpp/codegen/SpacesGenerator.kt
+++ b/plugin/src/main/kotlin/net/bladehunt/rpp/codegen/SpacesGenerator.kt
@@ -1,0 +1,70 @@
+package net.bladehunt.rpp.codegen
+
+import net.bladehunt.rpp.util.java
+import kotlin.math.pow
+
+private val javaFile = java(
+    """
+        package rpp_pkg;
+
+        import net.kyori.adventure.key.Key;
+        import net.kyori.adventure.text.Component;
+
+        import java.util.LinkedHashMap;
+        import java.lang.Math;
+
+        public class rpp_name {
+            public static Key FONT_KEY = Key.key("rpp_namespace", "rpp_font");
+        
+            private static char charFor(int n) {
+                return (char) ((n < 0 ? 57344 : 61440) + intSqrt(n));
+            }
+            
+            public static Component component(int amount) {
+                return Component.text(string(amount)).font(FONT_KEY);
+            }
+
+            public static String string(int amount) {
+                StringBuilder builder = new StringBuilder();
+                
+                int modifier = amount < 0 ? -1 : 1;
+                
+                amount = Math.abs(amount);
+        
+                while (true) {
+                    int highestAmount = Math.min(Integer.highestOneBit(amount), rpp_amount);
+                    if (highestAmount == 0) return builder.toString();
+                    
+                    builder.append(charFor(highestAmount * modifier));
+                    amount -= highestAmount;
+                }
+            }
+    
+            private static int intSqrt(int n) {
+                n = Math.abs(n);
+
+                if ((n & (n - 1)) != 0 || n > rpp_amount) {
+                    throw new IllegalArgumentException("Input must be a power of 2 and the absolute value must not be greater than rpp_amount.");
+                }
+
+                return Integer.numberOfTrailingZeros(n);
+            }
+        }
+    """.trimIndent()
+)
+
+internal fun createSpaceClass(
+    className: String,
+    classPackage: String,
+    namespace: String,
+    font: String,
+    amount: Int
+): String {
+    val amt = 2.0.pow(amount-1).toInt()
+    return javaFile
+        .replace("rpp_amount", amt.toString())
+        .replace("rpp_pkg", classPackage)
+        .replace("rpp_namespace", namespace)
+        .replace("rpp_font", font)
+        .replace("rpp_name", className)
+}

--- a/plugin/src/main/kotlin/net/bladehunt/rpp/codegen/SpacesGenerator.kt
+++ b/plugin/src/main/kotlin/net/bladehunt/rpp/codegen/SpacesGenerator.kt
@@ -17,7 +17,7 @@ private val javaFile = java(
             public static Key FONT_KEY = Key.key("rpp_namespace", "rpp_font");
         
             private static char charFor(int n) {
-                return (char) ((n < 0 ? 57344 : 61440) + intSqrt(n));
+                return (char) ((n < 0 ? 61440 : 57344) + intSqrt(n));
             }
             
             public static Component component(int amount) {

--- a/plugin/src/main/kotlin/net/bladehunt/rpp/spaces/Spaces.kt
+++ b/plugin/src/main/kotlin/net/bladehunt/rpp/spaces/Spaces.kt
@@ -1,0 +1,9 @@
+package net.bladehunt.rpp.spaces
+
+data class Spaces(
+    val namespace: String,
+    val font: String,
+    val amount: Int,
+    val className: String?,
+    val classPackage: String?,
+)

--- a/plugin/src/main/kotlin/net/bladehunt/rpp/spaces/SpacesFile.kt
+++ b/plugin/src/main/kotlin/net/bladehunt/rpp/spaces/SpacesFile.kt
@@ -1,0 +1,25 @@
+package net.bladehunt.rpp.spaces
+
+import kotlinx.serialization.json.encodeToStream
+import net.bladehunt.rpp.Json
+import net.bladehunt.rpp.codegen.FontDefinition
+import net.bladehunt.rpp.codegen.FontProvider
+import java.io.OutputStream
+import kotlin.math.pow
+
+internal fun writeSpaces(amount: Int, stream: OutputStream) = Json.encodeToStream(
+    FontDefinition(
+        listOf(
+            FontProvider.Space(
+                buildMap {
+                    for (i in 0..<amount) {
+                        put(Char(57344 + i).toString(), 2.0.pow(i).toFloat())
+                        put(Char(61440 + i).toString(), -2.0.pow(i).toFloat())
+                    }
+                }
+            )
+        )
+    ),
+    stream
+)
+

--- a/plugin/src/main/kotlin/net/bladehunt/rpp/util/ArchiveUtil.kt
+++ b/plugin/src/main/kotlin/net/bladehunt/rpp/util/ArchiveUtil.kt
@@ -7,6 +7,7 @@ import net.bladehunt.rpp.Json
 import net.bladehunt.rpp.RppExtension
 import net.bladehunt.rpp.codegen.CodegenConfig
 import net.bladehunt.rpp.codegen.generateCode
+import net.bladehunt.rpp.spaces.writeSpaces
 import org.gradle.api.Project
 import java.io.File
 import java.security.MessageDigest
@@ -35,12 +36,13 @@ internal fun Project.buildResourcePack(
     buildDir.file("$outputName.sha1").asFile.writeText(output.sha1())
 
     val generated = buildDir.dir("generated/java").asFile
+
     val codegenConfig: CodegenConfig = sourceDirectory
         .resolve("codegen.json")
         .takeIf { it.exists() }
         ?.inputStream()?.use { Json.decodeFromStream(it) } ?: return
 
-    generateCode(codegenConfig, sourceDirectory.resolve("assets"), generated)
+    generateCode(codegenConfig, extension.spaces, sourceDirectory.resolve("assets"), generated)
 }
 
 fun generateOutput(
@@ -53,7 +55,6 @@ fun generateOutput(
     if (!output.deleteRecursively()) throw IllegalStateException("Failed to clean output")
     if (!output.mkdir()) throw IllegalStateException("Failed to create output directory")
 
-    // TODO: update output generation
     val prefix = source.path
     val ignoredFiles = arrayListOf<Pattern>()
 
@@ -93,6 +94,14 @@ fun generateOutput(
             true
         )
     }
+
+    val spaces = extension.spaces ?: return
+    val spaceOutputDir = output.resolve("assets/${spaces.namespace}/font")
+
+    spaceOutputDir.mkdirs()
+    val spacesOutput = spaceOutputDir.resolve(spaces.font + ".json")
+    spacesOutput.createNewFile()
+    writeSpaces(spaces.amount, spacesOutput.outputStream())
 }
 
 fun archive(source: File, output: File) {


### PR DESCRIPTION
This generates a spaces.json font and java class.

Configuration:
```kt
rpp {
    // amount controls the number of both positive and negative space characters get generated
    spaces(amount = 16, className = "Spaces", classPackage = "com.example.generated.util", namespace = "rpp", font = "spaces")
}
```

Output:
```java
package com.example.generated.util;

import net.kyori.adventure.key.Key;
import net.kyori.adventure.text.Component;

import java.util.LinkedHashMap;
import java.lang.Math;

public class Spaces {
    public static Key FONT_KEY = Key.key("rpp", "spaces");

    private static char charFor(int n) {
        return (char) ((n < 0 ? 61440 : 57344) + intSqrt(n));
    }
    
    public static Component component(int amount) {
        return Component.text(string(amount)).font(FONT_KEY);
    }

    public static String string(int amount) {
        StringBuilder builder = new StringBuilder();
        
        int modifier = amount < 0 ? -1 : 1;
        
        amount = Math.abs(amount);

        while (true) {
            int highestAmount = Math.min(Integer.highestOneBit(amount), 32768);
            if (highestAmount == 0) return builder.toString();
            
            builder.append(charFor(highestAmount * modifier));
            amount -= highestAmount;
        }
    }

    private static int intSqrt(int n) {
        n = Math.abs(n);

        if ((n & (n - 1)) != 0 || n > 32768) {
            throw new IllegalArgumentException("Input must be a power of 2 and the absolute value must not be greater than 32768.");
        }

        return Integer.numberOfTrailingZeros(n);
    }
}
```

```json
{
    "providers": [{
        "type": "space",
        "advances": {
            "": 1.0,
            "": -1.0,
            "": 2.0,
            "": -2.0,
            "": 4.0,
            "": -4.0,
            "": 8.0,
            "": -8.0,
            "": 16.0,
            "": -16.0,
            "": 32.0,
            "": -32.0,
            "": 64.0,
            "": -64.0,
            "": 128.0,
            "": -128.0,
            "": 256.0,
            "": -256.0,
            "": 512.0,
            "": -512.0,
            "": 1024.0,
            "": -1024.0,
            "": 2048.0,
            "": -2048.0,
            "": 4096.0,
            "": -4096.0,
            "": 8192.0,
            "": -8192.0,
            "": 16384.0,
            "": -16384.0,
            "": 32768.0,
            "": -32768.0
        }
    }]
}
```